### PR TITLE
Use default template as a base for "normal" pages

### DIFF
--- a/templates/article.html.twig
+++ b/templates/article.html.twig
@@ -1,55 +1,37 @@
-{% extends 'partials/base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
+{% block innercontent %}
 
-	<div class="nav-spacer"></div>
-
-	<section class="section">
-		<div class="container">
-			<div class="columns is-centered">
-				<div class="column is-12">
-
-					<div class="content">
-						<h1>
-							{{ page.title }}
-						</h1>
-
-						{% if page.header.intro %}
-							<div class="is-size-5">
-								{{ page.header.intro|markdown }}
-							</div>
-						{% endif %}
-
-						{% if page.header.featured_image %}
-							<figure class="image " style="margin-left: 0; margin-right: 0;">
-								{{ page.media[page.header.featured_image].html('',page.title|escape)}}
-							</figure>
-						{% endif %}
-
-
-						<small class="is-italic is-size-10 has-text-grey">
-							Published: 
-							{{ page.header.publish_date|date("d.m.Y") }}
-						</small>
-
-						<hr>
-
-						{{ page.content }}
-					</div>
-
-					{% if page.header.taxonomy.tag %}
-						<div class="tags">
-							{% for tag in page.header.taxonomy.tag %}
-								<span class="tag">
-									{{ tag }}
-								</span>
-							{% endfor %}
-						</div>
-					{% endif %}
-
-				</div>
-
-			</div>
+	{% if page.header.intro %}
+		<div class="is-size-5">
+			{{ page.header.intro|markdown }}
 		</div>
-	</div>
-</section>{% endblock %}
+	{% endif %}
+
+	{% if page.header.featured_image %}
+		<figure class="image " style="margin-left: 0; margin-right: 0;">
+			{{ page.media[page.header.featured_image].html('',page.title|escape)}}
+		</figure>
+	{% endif %}
+
+
+	<small class="is-italic is-size-10 has-text-grey">
+		Published:
+		{{ page.header.publish_date|date("d.m.Y") }}
+	</small>
+
+	<hr>
+
+	{{ page.content }}
+
+	{% if page.header.taxonomy.tag %}
+		<div class="tags">
+			{% for tag in page.header.taxonomy.tag %}
+				<span class="tag">
+					{{ tag }}
+				</span>
+			{% endfor %}
+		</div>
+	{% endif %}
+
+{% endblock %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,31 +1,13 @@
-{% extends 'partials/base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
+{% block innercontent %}
 
-<div class="nav-spacer"></div>
+	{{ page.content }}
 
-<section class="section">
-    <div class="container">
-        <div class="columns is-centered">
-            <div class="column is-12">
+	<hr>
 
-                <div class="content">
-                    <h1>
-                        {{ page.title }}
-                    </h1>
-                    
-                    {{ page.content }}
-                </div>
-
-                <hr>
-
-                {% for post in page.find('/news').children.order('publish_date', 'desc') %}
-                    {% include 'partials/post.html.twig' %}
-                {% endfor %}
-
-            </div>
-        </div>
-    </div>
-</section>
+	{% for post in page.find('/news').children.order('publish_date', 'desc') %}
+		{% include 'partials/post.html.twig' %}
+	{% endfor %}
 
 {% endblock %}

--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -2,24 +2,27 @@
 
 {% block content %}
 
-<div class="nav-spacer"></div>
+	<div class="nav-spacer"></div>
 
-<section class="section">
-    <div class="container">
-        <div class="columns is-centered">
-            <div class="column is-12">
+	<section class="section">
+		<div class="container">
+			<div class="columns is-centered">
+				<div class="column is-12 content">
 
-                <div class="content">
-                    <h1>
-                        {{ page.title }}
-                    </h1>
-                    
-                    {{ page.content }}
-                </div>
+					{% block pagetitle %}
+						<h1>
+							{{ page.title }}
+						</h1>
+					{% endblock %}
 
-            </div>
-        </div>
-    </div>
-</section>
+
+					{% block innercontent %}
+						{{ page.content }}
+					{% endblock %}
+
+				</div>
+			</div>
+		</div>
+	</section>
 
 {% endblock %}

--- a/templates/event.html.twig
+++ b/templates/event.html.twig
@@ -1,54 +1,36 @@
-{% extends 'partials/base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
+{% block innercontent %}
 
-<div class="nav-spacer"></div>
+	{% if page.header.intro %}
+		<div class="is-size-5">
+			{{ page.header.intro|markdown }}
+		</div>
+	{% endif %}
 
-<section class="section">
-    <div class="container">
-        <div class="columns is-centered">
-            <div class="column is-8">
+	{% if page.header.featured_image %}
+		<figure class="image " style="margin-left: 0; margin-right: 0;">
+			{{ page.media[page.header.featured_image].html('',page.title|escape)}}
+		</figure>
+	{% endif %}
 
-            <div class="content">
-                <h1>
-                    {{ page.title }}
-                </h1>
+	<hr>
 
-                {% if page.header.intro %}
-                    <div class="is-size-5">
-                        {{ page.header.intro|markdown }}
-                    </div>
-                {% endif %}
+	{{ page.content }}
 
-                {% if page.header.featured_image %}
-                    <figure class="image " style="margin-left: 0; margin-right: 0;">
-                        {{ page.media[page.header.featured_image].html('',page.title|escape)}}
-                    </figure>
-                {% endif %}
+	{% if page.header.taxonomy.tag %}
+		<div class="tags">
+			{% for tag in page.header.taxonomy.tag %}
+				<span class="tag">
+					{{ tag }}
+				</span>
+			{% endfor %}
+		</div>
+	{% endif %}
 
-                <hr>
+	<small class="is-italic is-size-10 has-text-grey">
+		Veröffentlicht am
+		{{ page.header.publish_date|date("d.m.Y") }}
+	</small>
 
-                {{ page.content }}
-            </div>
-
-            {% if page.header.taxonomy.tag %}
-                <div class="tags">
-                    {% for tag in page.header.taxonomy.tag %}
-                        <span class="tag">
-                            {{ tag }}
-                        </span>
-                    {% endfor %}
-                </div>
-            {% endif %}
-
-            <small class="is-italic is-size-10 has-text-grey">
-                Veröffentlicht am {{ page.header.publish_date|date("d.m.Y") }}
-            </small>
-
-        </div>
-
-            </div>
-        </div>
-    </div>
-</section>
 {% endblock %}

--- a/templates/eventlist.html.twig
+++ b/templates/eventlist.html.twig
@@ -5,7 +5,7 @@
 	{{ page.content }}
 	<hr>
 
-	<h2>Upcomming</h1>
+	<h2>Upcoming</h1>
 	<hr>
 	{% for event in page.collection('upcoming') %}
 		{% include 'partials/event.html.twig' %}

--- a/templates/eventlist.html.twig
+++ b/templates/eventlist.html.twig
@@ -1,35 +1,20 @@
-{% extends 'partials/base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
+{% block innercontent %}
 
-<div class="nav-spacer"></div>
+	{{ page.content }}
+	<hr>
 
-<section class="section">
-    <div class="container">
-        <div class="columns is-centered">
-            <div class="column is-12">
+	<h2>Upcomming</h1>
+	<hr>
+	{% for event in page.collection('upcoming') %}
+		{% include 'partials/event.html.twig' %}
+	{% endfor %}
 
-                <div class="content">
-                    <h1>{{ page.title }}</h1>
-                    {{ page.content }}
-                </div>
-                <hr>
- 
-                <div class="content">
-                    <h2>Upcomming</h1>
-                        <hr>
-                        {% for event in page.collection('upcoming') %}
-                        {% include 'partials/event.html.twig' %}
-                        {% endfor %}
+	<h2>Past</h1>
+	<hr>
+	{% for event in page.collection('past') %}
+		{% include 'partials/event.html.twig' %}
+	{% endfor %}
 
-                    <h2>Past</h1>
-                        <hr>
-                        {% for event in page.collection('past') %}
-                        {% include 'partials/event.html.twig' %}
-                        {% endfor %}
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-{% endblock %} 
+{% endblock %}

--- a/templates/form.html.twig
+++ b/templates/form.html.twig
@@ -1,6 +1,6 @@
-{% extends 'partials/base.html.twig' %}
+{% extends 'default.html.twig' %}
 
-{% block content %}
+{% block innercontent %}
 
     {{ content|raw }}
     {% include "forms/form.html.twig" %}


### PR DESCRIPTION
Refactor the default template to be used as the base for normal pages. This way we can reduce redundant html for the inner content of these pages.